### PR TITLE
fix: paging on transactions

### DIFF
--- a/comdirect/cmd/root.go
+++ b/comdirect/cmd/root.go
@@ -47,7 +47,7 @@ func init() {
 	documentCmd.Flags().StringVar(&folderFlag, "folder", "", "folder to save downloads")
 	documentCmd.Flags().BoolVar(&downloadFlag, "download", false, "whether to download documents")
 
-	transactionCmd.PersistentFlags().StringVar(&sinceFlag, "since", time.Now().Add(time.Hour*-1*24*30).Format("2006-01-02"), "Date of the earliest transaction date to retrieve in the form YYYY-MM-DD")
+	transactionCmd.PersistentFlags().StringVar(&sinceFlag, "since", "", "Date of the earliest transaction date to retrieve in the form YYYY-MM-DD")
 
 	rootCmd.PersistentFlags().StringVar(&indexFlag, "index", "0", "page index")
 	rootCmd.PersistentFlags().StringVar(&countFlag, "count", "20", "page count")

--- a/comdirect/cmd/transaction.go
+++ b/comdirect/cmd/transaction.go
@@ -25,49 +25,22 @@ var (
 )
 
 func transaction(cmd *cobra.Command, args []string) {
-	const dateLayout = "2006-01-02"
-	since, err := time.Parse(dateLayout, sinceFlag)
-	if err != nil {
-		log.Fatalf("Failed to parse date from command line: %s", err)
-	}
-
-	client := initClient()
 	var transactions = &comdirect.AccountTransactions{}
+	var err error
+	client := initClient()
+	ctx, cancel := contextWithTimeout()
+	defer cancel()
 
-	page := 1
-	pageCount, err := strconv.Atoi(countFlag)
-	if err != nil {
-		log.Fatalf("Can't convert string to int: %s", err)
-	}
-	for {
+	if sinceFlag == "" {
 		options := comdirect.EmptyOptions()
-		options.Add(comdirect.PagingCountQueryKey, fmt.Sprint(pageCount*page))
-		options.Add(comdirect.PagingFirstQueryKey, fmt.Sprint(0))
-		ctx, cancel := contextWithTimeout()
-		defer cancel()
-
+		options.Add(comdirect.PagingCountQueryKey, countFlag)
+		options.Add(comdirect.PagingFirstQueryKey, indexFlag)
 		transactions, err = client.Transactions(ctx, args[0], options)
 		if err != nil {
-			log.Fatalf("Error retrieving transactions: %e", err)
+			log.Fatalf("Failed to retrieve transactions: %s", err)
 		}
-
-		if len(transactions.Values) == 0 {
-			break
-		}
-
-		lastDate, err := time.Parse(dateLayout, transactions.Values[len(transactions.Values)-1].BookingDate)
-		if err != nil {
-			log.Fatalf("Failed to parse date from command line: %s", err)
-		}
-		if transactions.Paging.Matches == len(transactions.Values) || lastDate.Before(since) {
-			break
-		}
-		page++
-	}
-
-	transactions, err = transactions.FilterSince(since)
-	if err != nil {
-		log.Fatalf("Error filtering transactions by date: %e", err)
+	} else {
+		transactions = getTransactionsSince(sinceFlag, client, args[0])
 	}
 
 	switch formatFlag {
@@ -80,6 +53,54 @@ func transaction(cmd *cobra.Command, args []string) {
 	default:
 		printTransactionTable(transactions)
 	}
+}
+
+func getTransactionsSince(since string, client *comdirect.Client, accountID string) *comdirect.AccountTransactions {
+	const dateLayout = "2006-01-02"
+	var transactions = &comdirect.AccountTransactions{}
+	ctx, cancel := contextWithTimeout()
+	defer cancel()
+
+	s, err := time.Parse(dateLayout, since)
+	if err != nil {
+		log.Fatalf("Failed to parse date from command line: %s", err)
+	}
+
+	page := 1
+	pageCount, err := strconv.Atoi(countFlag)
+	if err != nil {
+		log.Fatalf("Can't convert string to int: %s", err)
+	}
+	for {
+		options := comdirect.EmptyOptions()
+		options.Add(comdirect.PagingCountQueryKey, fmt.Sprint(pageCount*page))
+		options.Add(comdirect.PagingFirstQueryKey, fmt.Sprint(0))
+
+		transactions, err = client.Transactions(ctx, accountID, options)
+		if err != nil {
+			log.Fatalf("Error retrieving transactions: %e", err)
+		}
+
+		if len(transactions.Values) == 0 {
+			break
+		}
+
+		lastDate, err := time.Parse(dateLayout, transactions.Values[len(transactions.Values)-1].BookingDate)
+		if err != nil {
+			lastDate = time.Now()
+
+		}
+		if transactions.Paging.Matches == len(transactions.Values) || lastDate.Before(s) {
+			break
+		}
+		page++
+	}
+
+	transactions, err = transactions.FilterSince(s)
+	if err != nil {
+		log.Fatalf("Error filtering transactions by date: %e", err)
+	}
+	return transactions
 }
 
 func printJSON(v interface{}) {


### PR DESCRIPTION
It was broken in commit 515c113, because the count parameter was ignored with the new since flag. Now the since flag is empty per default and only if the parameter is set the transactions are filtered. Otherwise the count parameter is used.

Refs: #24